### PR TITLE
ScalaJS 1.x Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tags
 
 .bloop
 .metals
+metals.sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,10 @@ jobs:
     # stage="test" if no stage is specified
     - name: test 2.13
       scala: *scala_version_213
-      script: sbt ++$TRAVIS_SCALA_VERSION test
+      script: sbt ++$TRAVIS_SCALA_VERSION coreJVM/test
     - name: test 2.12
       scala: *scala_version_212
-      script: sbt ++$TRAVIS_SCALA_VERSION test
-    - name: test 2.11
-      scala: *scala_version_211
-      script: sbt ++$TRAVIS_SCALA_VERSION test
+      script: sbt ++$TRAVIS_SCALA_VERSION coreJVM/test
     # - name: mima
     #   script: sbt +mimaReportBinaryIssues
     - name: site

--- a/build.sbt
+++ b/build.sbt
@@ -77,8 +77,8 @@ lazy val site = project.in(file("site"))
 
 // General Settings
 lazy val commonSettings = Seq(
-  scalaVersion := "2.13.1",
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.10", "2.11.12"),
+  scalaVersion := "2.13.2",
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.11"),
   
   addCompilerPlugin("org.typelevel" % "kind-projector" % kindProjectorV cross CrossVersion.binary),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % betterMonadicForV)

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
-import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
-
-val catsV = "2.0.0"
-val catsEffectV = "2.0.0"
-val specs2V = "4.8.2"
+val catsV = "2.1.1"
+val catsEffectV = "2.1.3"
+val specs2V = "4.9.4"
 val kindProjectorV = "0.10.3"
 val betterMonadicForV = "0.3.1"
 
@@ -10,18 +8,27 @@ lazy val `agitation` = project.in(file("."))
   .disablePlugins(MimaPlugin)
   .enablePlugins(NoPublishPlugin)
   .settings(commonSettings)
-  .aggregate(core)
+  .aggregate(core.js, core.jvm)
 
-lazy val core = project.in(file("core"))
+lazy val core = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("core"))
   .disablePlugins(MimaPlugin)
   .settings(commonSettings)
   .settings(
-    name := "agitation"
+    name := "agitation",
+    libraryDependencies ++= Seq(
+    "org.typelevel"               %%% "cats-core"                  % catsV,
+    "org.typelevel"               %%% "cats-effect"                % catsEffectV,
+    "org.typelevel"               %%% "cats-effect-laws"           % catsEffectV   % Test,
+    "org.specs2"                  %%% "specs2-core"                % specs2V       % Test,
+    "org.specs2"                  %%% "specs2-scalacheck"          % specs2V       % Test
+  )
   )
 
 lazy val site = project.in(file("site"))
   .settings(commonSettings)
-  .dependsOn(core)
+  .dependsOn(core.jvm)
   .disablePlugins(MimaPlugin)
   .enablePlugins(MicrositesPlugin)
   .enablePlugins(MdocPlugin)
@@ -74,14 +81,7 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq(scalaVersion.value, "2.12.10", "2.11.12"),
   
   addCompilerPlugin("org.typelevel" % "kind-projector" % kindProjectorV cross CrossVersion.binary),
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % betterMonadicForV),
-  libraryDependencies ++= Seq(
-    "org.typelevel"               %% "cats-core"                  % catsV,
-    "org.typelevel"               %% "cats-effect"                % catsEffectV,
-    "org.typelevel"               %% "cats-effect-laws"           % catsEffectV   % Test,
-    "org.specs2"                  %% "specs2-core"                % specs2V       % Test,
-    "org.specs2"                  %% "specs2-scalacheck"          % specs2V       % Test
-  )
+  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % betterMonadicForV)
 )
 
 // Global Settings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.12")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "0.9.7")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.0.3")
 
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.0")
 
 addSbtPlugin("io.chrisdavenport" % "sbt-no-publish" % "0.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.47deg" % "sbt-microsites" % "0.9.7")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.0.3")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.33")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.1.0")
 
 addSbtPlugin("io.chrisdavenport" % "sbt-no-publish" % "0.1.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")


### PR DESCRIPTION
Adds ScalaJS 1.x support to agitation. Currently compiles as expected, ~but tests are failing~.

Also drops Scala 2.11, since there appears to be missing dependencies somewhere for that version once ScalaJS 1.x is added.